### PR TITLE
chore: tweak Cargo.toml manifest metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    # Framework
+    # Entrypoint
     "strut",
 
     # Components

--- a/strut/Cargo.toml
+++ b/strut/Cargo.toml
@@ -21,33 +21,33 @@ name = "strut"
 #
 [dependencies]
 # Core
-strut-core        = { path = "../strut_core" }
+strut-core        = { path = "../strut_core", version = "0.0.1" }
 
 # Runtime
 tokio             = { workspace = true, features = ["rt-multi-thread", "sync"] }
 
 # Config
-strut-config      = { path = "../strut_config" }
-strut-factory     = { path = "../strut_factory" }
-strut-deserialize = { path = "../strut_deserialize" }
+strut-config      = { path = "../strut_config",      version = "0.0.1" }
+strut-factory     = { path = "../strut_factory",     version = "0.0.1" }
+strut-deserialize = { path = "../strut_deserialize", version = "0.0.1" }
 config            = { workspace = true, features = [] }
 serde             = { workspace = true, features = ["std", "derive"] }
 dotenvy           = { workspace = true, features = [] }
 parking_lot       = { workspace = true, features = [] }
 
 # Tracing
-strut-tracing     = { optional = true, path = "../strut_tracing" }
+strut-tracing     = { optional = true, path = "../strut_tracing",  version = "0.0.1" }
 tracing           = { optional = true, workspace = true, features = [] }
 tracing-log       = { optional = true, workspace = true, features = ["std", "log-tracer"] }
 
 # Sentry
-strut-sentry      = { optional = true, path = "../strut_sentry" }
+strut-sentry      = { optional = true, path = "../strut_sentry",   version = "0.0.1" }
 
 # Database
-strut-database    = { optional = true, path = "../strut_database" }
+strut-database    = { optional = true, path = "../strut_database", version = "0.0.1" }
 
 # RabbitMQ
-strut-rabbitmq    = { optional = true, path = "../strut_rabbitmq" }
+strut-rabbitmq    = { optional = true, path = "../strut_rabbitmq", version = "0.0.1" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/strut/Cargo.toml
+++ b/strut/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut/Cargo.toml
+++ b/strut/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "Backend in Rust: convenient and configurable with Strut."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["backend", "convenient", "configurable", "asynchronous", "modular"]
 publish        = true
 
 [lib]

--- a/strut_config/Cargo.toml
+++ b/strut_config/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "A companion to `config` crate. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns", "filesystem"]
+keywords       = ["internal", "helper", "config", "filesystem", "environment"]
 publish        = true
 
 [lib]

--- a/strut_config/Cargo.toml
+++ b/strut_config/Cargo.toml
@@ -20,7 +20,7 @@ name = "strut_config"
 # DEPENDENCIES
 #
 [dependencies]
-strut-core = { path = "../strut_core" }
+strut-core = { path = "../strut_core", version = "0.0.1" }
 config     = { workspace = true, features = ["toml", "yaml"] }
 
 #

--- a/strut_config/Cargo.toml
+++ b/strut_config/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-config"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_config/src/scanner.rs
+++ b/strut_config/src/scanner.rs
@@ -71,8 +71,8 @@ impl Scanner {
         config_files
     }
 
-    /// Resolves the application’s **configuration directory**: where the
-    /// framework looks for configuration files.
+    /// Resolves the application’s **configuration directory**: where Strut
+    /// looks for configuration files.
     ///
     /// Dynamically determines the path at runtime.
     ///

--- a/strut_core/Cargo.toml
+++ b/strut_core/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-core"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_core/Cargo.toml
+++ b/strut_core/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "Core facades and utilities. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["internal", "core", "synchronization", "profile"]
 publish        = true
 
 [lib]

--- a/strut_core/src/lib.rs
+++ b/strut_core/src/lib.rs
@@ -36,8 +36,8 @@ pub const ALERT_FIELD_NAME: &str = "alert";
 ///
 /// ## Usage
 ///
-/// When using any of the public `strut` components without the framework
-/// itself, await on this function as a last thing before completing the main
+/// When using any of the Strut components without the `strut` crate itself,
+/// await on this function as a last thing before completing the main
 /// application logic.
 pub async fn strut_shutdown() {
     // Terminate the global application context

--- a/strut_database/Cargo.toml
+++ b/strut_database/Cargo.toml
@@ -21,11 +21,11 @@ name = "strut_database"
 #
 [dependencies]
 # Internal
-strut-factory     = { path = "../strut_factory" }
-strut-deserialize = { path = "../strut_deserialize" }
-strut-sync        = { path = "../strut_sync" }
-strut-core        = { path = "../strut_core" }
-strut-util        = { path = "../strut_util", features = ["backoff"] }
+strut-factory     = { path = "../strut_factory",     version = "0.0.1" }
+strut-deserialize = { path = "../strut_deserialize", version = "0.0.1" }
+strut-sync        = { path = "../strut_sync",        version = "0.0.1" }
+strut-core        = { path = "../strut_core",        version = "0.0.1" }
+strut-util        = { path = "../strut_util",        version = "0.0.1", features = ["backoff"] }
 
 # External
 sqlx              = { workspace = true, features = ["runtime-tokio"] }

--- a/strut_database/Cargo.toml
+++ b/strut_database/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "A convenience layer around `sqlx` crate. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns", "database"]
+keywords       = ["component", "mysql", "postgresql", "sqlite", "connection"]
 publish        = true
 
 [lib]

--- a/strut_database/Cargo.toml
+++ b/strut_database/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-database"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_database/src/lib.rs
+++ b/strut_database/src/lib.rs
@@ -55,6 +55,6 @@ pub use sqlx;
 /// Re-exports the `strut_shutdown` function to facilitate stand-alone usage of
 /// this crate.
 ///
-/// When using this crate without the `strut` framework itself, await on this
+/// When using this crate without the `strut` crate itself, await on this
 /// function as a last thing before completing the main application logic.
 pub use strut_core::strut_shutdown;

--- a/strut_deserialize/Cargo.toml
+++ b/strut_deserialize/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "Deserialization utilities. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns", "parsing"]
+keywords       = ["internal", "deserialization", "flexible", "human-readable"]
 publish        = true
 
 [lib]

--- a/strut_deserialize/Cargo.toml
+++ b/strut_deserialize/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-deserialize"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_factory/Cargo.toml
+++ b/strut_factory/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "Procedural macros. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["internal", "procedural-macros"]
 publish        = true
 
 [lib]

--- a/strut_factory/Cargo.toml
+++ b/strut_factory/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-factory"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_factory/Cargo.toml
+++ b/strut_factory/Cargo.toml
@@ -27,7 +27,7 @@ syn          = { workspace = true, features = ["clone-impls", "derive", "full", 
 convert_case = { workspace = true, features = [] }
 
 [dev-dependencies]
-strut             = { path = "../strut" }
+strut             = { path = "../strut", version = "0.0.1" }
 pretty_assertions = { workspace = true }
 serde             = { workspace = true }
 serde_json        = { workspace = true }

--- a/strut_rabbitmq/Cargo.toml
+++ b/strut_rabbitmq/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-rabbitmq"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_rabbitmq/Cargo.toml
+++ b/strut_rabbitmq/Cargo.toml
@@ -21,11 +21,11 @@ name = "strut_rabbitmq"
 #
 [dependencies]
 # Internal
-strut-factory        = { path = "../strut_factory" }
-strut-deserialize    = { path = "../strut_deserialize" }
-strut-sync           = { path = "../strut_sync" }
-strut-util           = { path = "../strut_util", features = ["backoff"] }
-strut-core           = { path = "../strut_core" }
+strut-factory        = { path = "../strut_factory",     version = "0.0.1" }
+strut-deserialize    = { path = "../strut_deserialize", version = "0.0.1" }
+strut-sync           = { path = "../strut_sync",        version = "0.0.1" }
+strut-util           = { path = "../strut_util",        version = "0.0.1", features = ["backoff"] }
+strut-core           = { path = "../strut_core",        version = "0.0.1" }
 
 # External
 lapin                = { workspace = true, features = ["rustls"] }

--- a/strut_rabbitmq/Cargo.toml
+++ b/strut_rabbitmq/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "A convenience layer around `lapin` crate. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["component", "messaging", "amqp", "rabbitmq"]
 publish        = true
 
 [lib]

--- a/strut_rabbitmq/src/lib.rs
+++ b/strut_rabbitmq/src/lib.rs
@@ -106,6 +106,6 @@ pub use self::repr::ingress::{AckingBehavior, HeadersMatchingBehavior};
 /// Re-exports the `strut_shutdown` function to facilitate stand-alone usage of
 /// this crate.
 ///
-/// When using this crate without the `strut` framework itself, await on this
+/// When using this crate without the `strut` crate itself, await on this
 /// function as a last thing before completing the main application logic.
 pub use strut_core::strut_shutdown;

--- a/strut_sentry/Cargo.toml
+++ b/strut_sentry/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-sentry"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_sentry/Cargo.toml
+++ b/strut_sentry/Cargo.toml
@@ -21,9 +21,9 @@ name = "strut_sentry"
 #
 [dependencies]
 # Internal
-strut-factory      = { path = "../strut_factory" }
-strut-deserialize  = { path = "../strut_deserialize" }
-strut-core         = { path = "../strut_core" }
+strut-factory      = { path = "../strut_factory",     version = "0.0.1" }
+strut-deserialize  = { path = "../strut_deserialize", version = "0.0.1" }
+strut-core         = { path = "../strut_core",        version = "0.0.1" }
 
 # External
 sentry             = { workspace = true, features = ["backtrace", "contexts", "debug-images", "panic", "transport", "release-health"] }

--- a/strut_sentry/Cargo.toml
+++ b/strut_sentry/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "Integration with Sentry. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns", "development-tools::debugging"]
+keywords       = ["component", "alerting", "sentry"]
 publish        = true
 
 [lib]

--- a/strut_sentry/src/lib.rs
+++ b/strut_sentry/src/lib.rs
@@ -20,6 +20,6 @@ pub mod tracing;
 /// Re-exports the `strut_shutdown` function to facilitate stand-alone usage of
 /// this crate.
 ///
-/// When using this crate without the `strut` framework itself, await on this
+/// When using this crate without the `strut` crate itself, await on this
 /// function as a last thing before completing the main application logic.
 pub use strut_core::strut_shutdown;

--- a/strut_sync/Cargo.toml
+++ b/strut_sync/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-sync"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_sync/Cargo.toml
+++ b/strut_sync/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "Synchronization primitives. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["internal", "synchronization", "utilities"]
 publish        = true
 
 [lib]

--- a/strut_tracing/Cargo.toml
+++ b/strut_tracing/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-tracing"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_tracing/Cargo.toml
+++ b/strut_tracing/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "A convenience layer around `tracing` crate. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns", "development-tools::debugging"]
+keywords       = ["component", "tracing", "logging", "console"]
 publish        = true
 
 [lib]

--- a/strut_tracing/Cargo.toml
+++ b/strut_tracing/Cargo.toml
@@ -21,8 +21,8 @@ name = "strut_tracing"
 #
 [dependencies]
 # Internal
-strut-factory      = { path = "../strut_factory" }
-strut-deserialize  = { path = "../strut_deserialize" }
+strut-factory      = { path = "../strut_factory",     version = "0.0.1" }
+strut-deserialize  = { path = "../strut_deserialize", version = "0.0.1" }
 
 # External
 tracing-core       = { workspace = true, features = [] }

--- a/strut_util/Cargo.toml
+++ b/strut_util/Cargo.toml
@@ -5,6 +5,7 @@ edition        = "2024"
 rust-version   = "1.85.0"
 authors        = ["Erik Sargazakov <erik@serpnet.org>"]
 license        = "MIT"
+documentation  = "https://docs.rs/strut-util"
 readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"

--- a/strut_util/Cargo.toml
+++ b/strut_util/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "In-house utilities. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["internal", "utilities"]
 publish        = true
 
 [lib]

--- a/test_strut/Cargo.toml
+++ b/test_strut/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "System tests for `strut` crate. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["non-public", "system", "tests"]
 publish        = false
 
 [lib]

--- a/test_strut_rabbitmq/Cargo.toml
+++ b/test_strut_rabbitmq/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "System tests for `strut-rabbitmq` crate. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["non-public", "system", "tests", "rabbitmq"]
 publish        = false
 
 [lib]

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -9,8 +9,8 @@ readme         = "README.md"
 repository     = "https://github.com/strut-rs/strut"
 homepage       = "https://strut-rs.github.io"
 description    = "Test-related utilities. Part of the Strut family."
-categories     = ["asynchronous", "config", "database", "web-programming"]
-keywords       = ["opinionated", "application", "framework"]
+categories     = ["asynchronous", "config", "rust-patterns"]
+keywords       = ["non-public", "system", "tests", "utilities"]
 publish        = false
 
 [lib]


### PR DESCRIPTION
Prepare Cargo.toml manifests for initial release. Add documentation link. Diversify categories and keywords to match more closely (within Cargo-imposed constraints) to package role.