### PR TITLE
chore: establish CHANGELOGs across packages

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,179 @@
+[changelog]
+trim = true
+
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+
+body = """
+{#- Helper: generate GitHub repo URL #}
+{%- macro remote_url() -%}
+    https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro %}
+
+{#- Helper: print single commit #}
+{%- macro print_commit(commit) %}
+    {%- set msg = commit.message | upper_first %}
+    {%- if commit.remote.pr_number %}
+        {%- set suffix = ' ([#' ~ commit.remote.pr_number ~ '])' %}
+        {%- set msg = msg | trim_end_matches(pat=suffix) %}
+    {%- endif -%}
+    - {% if commit.scope %}`{{ commit.scope }}`: {% endif %}
+      {%- if commit.breaking %}[**breaking**] {% endif %}
+      {{- msg }}
+      {%- if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]){% endif %}
+      {%- if commit.id %} ([{{ commit.id | truncate(length=7, end="") }}]){% endif %}
+{%- endmacro %}
+
+{#- Extract short version from tag #}
+{%- if version %}
+    {%- set short_version = version | split(pat="-") | last | trim_start_matches(pat="v") %}
+{%- else %}
+    {%- set short_version = "Unreleased" %}
+{%- endif %}
+
+{#- Compose version URL #}
+{%- set version_url = "" %}
+{%- set base_url = "https://github.com/" ~ remote.github.owner ~ "/" ~ remote.github.repo %}
+{%- if previous.version %}
+    {%- if version %}
+        {%- set version_url = base_url ~ "/compare/" ~ previous.version ~ ".." ~ version %}
+    {%- else %}
+        {%- set version_url = base_url ~ "/compare/" ~ previous.version ~ "..HEAD" %}
+    {%- endif %}
+{%- else %}
+    {%- if version %}
+        {%- set version_url = base_url ~ "/releases/tag/" ~ version %}
+    {%- endif %}
+{%- endif %}
+
+{#- Compose version heading #}
+{%- if version_url %}
+    {%- set version_heading = "[" ~ short_version ~ "](" ~ version_url ~ ")" %}
+{%- else %}
+    {%- set version_heading = short_version %}
+{%- endif %}
+
+{#- Store the list of commits to render #}
+{%- set rendered_commits = commits
+    | filter(attribute="merge_commit", value=false)
+    | unique(attribute="message")
+%}
+
+{#- Collect all issue numbers from all commits into a single list #}
+{%- set issue_nums = [] %}
+{%- for commit in rendered_commits %}
+    {%- if commit.links %}
+        {%- for link in commit.links %}
+            {%- set issue_num = link.text | int %}
+            {%- set_global issue_nums = issue_nums | concat(with=issue_num) %}
+        {%- endfor %}
+    {%- endif %}
+{%- endfor %}
+{#- Collect all links from all commits into a single list #}
+{%- for commit in rendered_commits %}
+    {%- if commit.remote.pr_number %}
+        {%- set pr_num = commit.remote.pr_number | int %}
+        {%- set_global issue_nums = issue_nums | concat(with=pr_num) %}
+    {%- endif %}
+{%- endfor %}
+
+{#- Now that we have a flat list, remove duplicates and sort it #}
+{%- set issue_nums = issue_nums | sort | unique %}
+
+{#- Print out the version heading #}
+## {{ version_heading }}{% if version %} - {{ timestamp | date(format="%Y-%m-%d") }}{%- endif %}
+
+{#- Loop through commits by group and print them #}
+{%- for group, commits in rendered_commits | group_by(attribute="group") %}
+    {%- raw %}\n{% endraw %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits
+        | filter(attribute="scope")
+        | sort(attribute="scope")
+    %}
+        {{ self::print_commit(commit=commit) }}
+    {%- endfor %}
+
+    {%- for commit in commits %}
+        {%- if not commit.scope %}
+            {{ self::print_commit(commit=commit) }}
+        {%- endif %}
+    {%- endfor %}
+{%- endfor %}
+
+{%- if not rendered_commits %}
+    {%- raw %}\n{% endraw %}
+    _No changes logged for this version._
+{%- endif %}
+
+{#- Create the issue link reference table #}
+{%- if issue_nums %}
+    {%- raw %}\n{% endraw %}
+    {%- for issue_num in issue_nums %}
+        [#{{ issue_num }}]: {{ self::remote_url() }}/issues/{{ issue_num }}
+    {%- endfor %}
+{%- endif %}
+
+{#- Create the commit link reference table #}
+{%- if rendered_commits %}
+    {%- raw %}\n{% endraw %}
+    {%- for commit in rendered_commits %}
+        {%- if commit.id %}
+            [{{ commit.id | truncate(length=7, end="") }}]: {{ self::remote_url() }}/commit/{{ commit.id }}
+        {%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- raw %}\n{% endraw %}
+"""
+
+[git]
+protect_breaking_commits = true
+
+commit_preprocessors = [
+    # Replace #123 with [#123] in the commit message
+    { pattern = '#(\d+)', replace = '[#$1]' },
+    # Replace !123 with [#123] in the commit message
+    { pattern = '!(\d+)', replace = '[#$1]' },
+]
+
+link_parsers = [
+    # Extract #123 and turn it into a GitHub issue link object
+    { pattern = '#(\d+)', text = '$1', href = 'https://github.com/strut-rs/strut/issues/$1' },
+    # Extract !123 and turn it into a GitHub issue link object
+    { pattern = '!(\d+)', text = '$1', href = 'https://github.com/strut-rs/strut/issues/$1' },
+]
+
+commit_parsers = [
+    { footer = "^Changelog: ?ignore", skip = true },
+
+    { message = "^feat", group = "<!-- 0 -->Features ⛰️" },
+    { message = "^fix", group = "<!-- 1 -->Bug Fixes 🐛" },
+
+    { message = "^refactor\\(clippy\\)", skip = true },
+    { message = "^refactor", group = "<!-- 2 -->Refactor 🚜" },
+    { message = "^doc", group = "<!-- 3 -->Documentation 📚" },
+    { message = "^perf", group = "<!-- 4 -->Performance ⚡" },
+    { message = "^style", group = "<!-- 5 -->Styling 🎨" },
+    { message = "^test", group = "<!-- 6 -->Testing 🧪" },
+
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+
+    { message = "^chore|^ci", group = "<!-- 7 -->Miscellaneous Tasks ⚙️" },
+    { message = "^security", group = "<!-- 8 -->Security 🛡️" },
+    { message = "^revert", group = "<!-- 9 -->Revert ◀️" },
+
+    { message = ".*", group = "<!-- 10 -->Other 💼" },
+]
+
+[remote.github]
+owner = "strut-rs"
+repo = "strut"

--- a/cliff.toml
+++ b/cliff.toml
@@ -154,10 +154,10 @@ commit_parsers = [
     { footer = "^Changelog: ?ignore", skip = true },
 
     { message = "^feat", group = "<!-- 0 -->Features ⛰️" },
-    { message = "^fix", group = "<!-- 1 -->Bug Fixes 🐛" },
+    { message = "^fix", group = "<!-- 1 -->Bug fixes 🐛" },
 
     { message = "^refactor\\(clippy\\)", skip = true },
-    { message = "^refactor", group = "<!-- 2 -->Refactor 🚜" },
+    { message = "^refactor", group = "<!-- 2 -->Refactoring 🚜" },
     { message = "^doc", group = "<!-- 3 -->Documentation 📚" },
     { message = "^perf", group = "<!-- 4 -->Performance ⚡" },
     { message = "^style", group = "<!-- 5 -->Styling 🎨" },
@@ -167,7 +167,7 @@ commit_parsers = [
     { message = "^chore\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
 
-    { message = "^chore|^ci", group = "<!-- 7 -->Miscellaneous Tasks ⚙️" },
+    { message = "^chore|^ci", group = "<!-- 7 -->Miscellaneous ⚙️" },
     { message = "^security", group = "<!-- 8 -->Security 🛡️" },
     { message = "^revert", group = "<!-- 9 -->Revert ◀️" },
 

--- a/justfile
+++ b/justfile
@@ -256,6 +256,90 @@ _ci_test_rabbitmq:
     set +x
 
 ##
+## Release & publish
+## Commands for generating changelogs, tagging commits, and publishing packages to Crates.io
+##
+
+tag version package_suffix='':
+    if [ '{{package_suffix}}' = '' ]; \
+    then just _tag_root '{{version}}'; \
+    else just _tag_sub '{{version}}' '{{package_suffix}}'; \
+    fi
+
+tag_all version:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    just _tag_root '{{version}}'
+    for package_suffix in \
+        macros \
+        util \
+        core \
+        alternative \
+    ; do just _tag_sub '{{version}}' "$package_suffix"; done
+
+_tag_root version:
+    [ -d 'strut' ]
+    git tag -a 'strut-{{version}}' -m 'chore: prepare strut v{{version}}'
+
+_tag_sub version package_suffix:
+    [ -d 'strut_{{package_suffix}}' ]
+    git tag -a 'strut-{{package_suffix}}-{{version}}' -m 'chore: prepare strut-{{package_suffix}} v{{version}}'
+
+cl_new version package_suffix='':
+    if [ '{{package_suffix}}' = '' ]; \
+    then just _cl_new_root '{{version}}'; \
+    else just _cl_new_sub '{{version}}' '{{package_suffix}}'; \
+    fi
+
+cl_new_all version:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    just _cl_new_root '{{version}}'
+    for package_suffix in \
+        macros \
+        util \
+        core \
+        alternative \
+    ; do
+        just _cl_new_sub '{{version}}' "$package_suffix"
+    done
+
+_cl_new_root version:
+    [ -d 'strut' ]
+    git cliff -c '../cliff.toml' -w 'strut' --include-path 'strut/**/*' --tag-pattern 'strut-\d+\.\d+\.\d+' --tag 'strut-{{version}}' --output 'strut/CHANGELOG.md' --unreleased
+
+_cl_new_sub version package_suffix:
+    [ -d 'strut_{{package_suffix}}' ]
+    git cliff -c '../cliff.toml' -w 'strut_{{package_suffix}}' --include-path 'strut_{{package_suffix}}/**/*' --tag-pattern 'strut-{{package_suffix}}-\d+\.\d+\.\d+' --tag 'strut-{{package_suffix}}-{{version}}' --output 'strut_{{package_suffix}}/CHANGELOG.md' --unreleased
+
+cl_prepend version package_suffix='':
+    if [ '{{package_suffix}}' = '' ]; \
+    then just _cl_prepend_root '{{version}}'; \
+    else just _cl_prepend_sub '{{version}}' '{{package_suffix}}'; \
+    fi
+
+cl_prepend_all version:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    just _cl_prepend_root '{{version}}'
+    for package_suffix in \
+        macros \
+        util \
+        core \
+        alternative \
+    ; do
+        just _cl_prepend_sub '{{version}}' "$package_suffix"
+    done
+
+_cl_prepend_root version:
+    [ -d 'strut' ]
+    git cliff -c '../cliff.toml' -w 'strut' --include-path 'strut/**/*' --tag-pattern 'strut-\d+\.\d+\.\d+' --tag 'strut-{{version}}' --prepend 'CHANGELOG.md' --unreleased
+
+_cl_prepend_sub version package_suffix:
+    [ -d 'strut_{{package_suffix}}' ]
+    git cliff -c '../cliff.toml' -w 'strut_{{package_suffix}}' --include-path 'strut_{{package_suffix}}/**/*' --tag-pattern 'strut-{{package_suffix}}-\d+\.\d+\.\d+' --tag 'strut-{{package_suffix}}-{{version}}' --prepend 'CHANGELOG.md' --unreleased
+
+##
 ## Bootstrap
 ## One-time commands for getting started with this project
 ##

--- a/justfile
+++ b/justfile
@@ -270,12 +270,13 @@ tag_all version:
     #!/usr/bin/env bash
     set -euxo pipefail
     just _tag_root '{{version}}'
-    for package_suffix in \
-        macros \
-        util \
-        core \
-        alternative \
-    ; do just _tag_sub '{{version}}' "$package_suffix"; done
+    for d in strut_*/; do
+        if [ -d "$d" ]; then
+            package_suffix="${d#strut_}"
+            package_suffix="${package_suffix%/}"
+            just _tag_sub '{{version}}' "$package_suffix"
+        fi
+    done
 
 _tag_root version:
     [ -d 'strut' ]
@@ -295,13 +296,12 @@ cl_new_all version:
     #!/usr/bin/env bash
     set -euxo pipefail
     just _cl_new_root '{{version}}'
-    for package_suffix in \
-        macros \
-        util \
-        core \
-        alternative \
-    ; do
-        just _cl_new_sub '{{version}}' "$package_suffix"
+    for d in strut_*/; do
+        if [ -d "$d" ]; then
+            package_suffix="${d#strut_}"
+            package_suffix="${package_suffix%/}"
+            just _cl_new_sub '{{version}}' "$package_suffix"
+        fi
     done
 
 _cl_new_root version:
@@ -322,13 +322,12 @@ cl_prepend_all version:
     #!/usr/bin/env bash
     set -euxo pipefail
     just _cl_prepend_root '{{version}}'
-    for package_suffix in \
-        macros \
-        util \
-        core \
-        alternative \
-    ; do
-        just _cl_prepend_sub '{{version}}' "$package_suffix"
+    for d in strut_*/; do
+        if [ -d "$d" ]; then
+            package_suffix="${d#strut_}"
+            package_suffix="${package_suffix%/}"
+            just _cl_prepend_sub '{{version}}' "$package_suffix"
+        fi
     done
 
 _cl_prepend_root version:

--- a/strut/CHANGELOG.md
+++ b/strut/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_config/CHANGELOG.md
+++ b/strut_config/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-config-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_core/CHANGELOG.md
+++ b/strut_core/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-core-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_database/CHANGELOG.md
+++ b/strut_database/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-database-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_deserialize/CHANGELOG.md
+++ b/strut_deserialize/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-deserialize-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_factory/CHANGELOG.md
+++ b/strut_factory/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-factory-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_rabbitmq/CHANGELOG.md
+++ b/strut_rabbitmq/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-rabbitmq-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_sentry/CHANGELOG.md
+++ b/strut_sentry/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-sentry-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_sync/CHANGELOG.md
+++ b/strut_sync/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-sync-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_tracing/CHANGELOG.md
+++ b/strut_tracing/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-tracing-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b

--- a/strut_util/CHANGELOG.md
+++ b/strut_util/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1](https://github.com/strut-rs/strut/releases/tag/strut-util-0.0.1) - 2025-08-21
+
+### Miscellaneous ⚙️
+
+- Initial commit ([e9f2e1f])
+
+[e9f2e1f]: https://github.com/strut-rs/strut/commit/e9f2e1fdf6bbd17de9d5a3c47c0b9e0224549e4b


### PR DESCRIPTION
Establish `git-cliff` and `just` as main tools for CHANGELOG management. Add initial CHANGELOG.md files to publish-able packages.
